### PR TITLE
Fix Bootstrap scripts names to point the correct files

### DIFF
--- a/theme/layout/theme.liquid
+++ b/theme/layout/theme.liquid
@@ -29,10 +29,10 @@
   {{ 'collapse.js' | asset_url | script_tag }}
   {{ 'dropdown.js' | asset_url | script_tag }}
   {{ 'modal.js' | asset_url | script_tag }}
+  {{ 'tooltip.js' | asset_url | script_tag }}
   {{ 'popover.js' | asset_url | script_tag }}
   {{ 'scrollspy.js' | asset_url | script_tag }}
   {{ 'tab.js' | asset_url | script_tag }}
-  {{ 'tooltip.js' | asset_url | script_tag }}
   {{ 'transition.js' | asset_url | script_tag }}
   
   {{ content_for_header }}


### PR DESCRIPTION
Bootstrap scripts names point to deleted old Bootstrap 2 scripts. Fixed to load the proper Bootstrap 3 files.
