### PR TITLE
Fixed Open Graph image meta tags

### DIFF
--- a/theme/snippets/meta.liquid
+++ b/theme/snippets/meta.liquid
@@ -20,10 +20,24 @@
 {% else %}
 <meta property="og:type" content="website" />
 {% endif %}
-{% if product.featured_image != blank %}
-<meta property="og:image" content="{{ product.featured_image | product_img_url: 'medium' }}" />
-{% elsif settings.logo-image %}
-<meta property="og:image" content="{{ 'logo-image-file.png' | asset_url }}" />
+{% if template contains 'product' %}
+  <meta property="og:image" content="http:{{ product.featured_image.src | product_img_url: 'grande' }}" />
+  <meta property="og:image:secure_url" content="https:{{ product.featured_image.src | product_img_url: 'grande' }}" />
+{% elsif template contains 'article' %} 
+  {% assign img_tag = '<' | append: 'img' %}
+  {% if article.content contains img_tag %}
+    {% assign src = article.content | split: 'src="' %}
+    {% assign src = src[1] | split: '"' | first | remove: 'https:' | remove: 'http:' %}
+    {% if src %}
+      <meta property="og:image" content="http:{{ src }}" />
+      <meta property="og:image:secure_url" content="https:{{ src }}" />
+    {% endif %}
+  {% endif %}
+{% else %}
+  {% if settings.logo-image %}
+    <meta property="og:image" content="http:{{ 'logo-image-file.png' | asset_url }}" />
+    <meta property="og:image:secure_url" content="https:{{ 'logo-image-file.png' | asset_url }}" />
+  {% endif %}
 {% endif %}
 <meta property="og:site_name" content="{{ shop.name }}" />
 


### PR DESCRIPTION
According to http://docs.shopify.com/manual/configuration/store-customization/social-media/facebook/why-do-i-not-see-the-right-image-on-facebook
Facebook does not detect URL independend images. I adopted the shopify solution to work with bootstrapify.
the logo will typically not work with Facebook because it will be smaller than the expected minimum of 200x200px
